### PR TITLE
fix zip file stream getting stuck

### DIFF
--- a/src/services/fs.ts
+++ b/src/services/fs.ts
@@ -4,7 +4,7 @@ import * as fs from 'promise-fs';
 import { ElectronFile } from '../types';
 import StreamZip from 'node-stream-zip';
 import { Readable } from 'stream';
-import { logErrorSentry } from './sentry';
+import { logError } from './logging';
 
 // https://stackoverflow.com/a/63111390
 export const getDirFilePaths = async (dirPath: string) => {
@@ -165,7 +165,7 @@ export const getZipFileStream = async (
                     controller.close();
                 }
             } catch (e) {
-                logErrorSentry(e, 'readableStream pull failed');
+                logError(e, 'readableStream pull failed');
                 controller.close();
             }
         },


### PR DESCRIPTION
## Description

fixes  `readStreamData` getting stuck when its called before `end` event was fired but after the last `readable` event  called

## Test Plan

- [x] verified that the fix works
- [x] through testing with multiple file sizes 
