### PR TITLE
Use stream for temp file creation

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -22,11 +22,11 @@ export const checkExistsAndRename = async (
     }
 };
 
-export const saveStreamToDisk = (
+export const saveStreamToDisk = async (
     filePath: string,
-    fileStream: ReadableStream<any>
+    fileStream: ReadableStream<Uint8Array>
 ) => {
-    writeStream(filePath, fileStream);
+    await writeStream(filePath, fileStream);
 };
 
 export const saveFileToDisk = async (path: string, fileData: any) => {

--- a/src/api/ffmpeg.ts
+++ b/src/api/ffmpeg.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron';
 import { existsSync } from 'fs';
+import { writeStream } from '../services/fs';
 import { logError } from '../services/logging';
 import { ElectronFile } from '../types';
 
@@ -12,12 +13,8 @@ export async function runFFmpegCmd(
     let createdTempInputFile = null;
     try {
         if (!existsSync(inputFile.path)) {
-            const inputFileData = new Uint8Array(await inputFile.arrayBuffer());
-            inputFilePath = await ipcRenderer.invoke(
-                'write-temp-file',
-                inputFileData,
-                inputFile.name
-            );
+            const tempFilePath = await ipcRenderer.invoke('get-temp-file-path');
+            inputFilePath = writeStream(tempFilePath, await inputFile.stream());
             createdTempInputFile = true;
         } else {
             inputFilePath = inputFile.path;

--- a/src/api/ffmpeg.ts
+++ b/src/api/ffmpeg.ts
@@ -13,8 +13,12 @@ export async function runFFmpegCmd(
     let createdTempInputFile = null;
     try {
         if (!existsSync(inputFile.path)) {
-            const tempFilePath = await ipcRenderer.invoke('get-temp-file-path');
-            inputFilePath = writeStream(tempFilePath, await inputFile.stream());
+            const tempFilePath = await ipcRenderer.invoke(
+                'get-temp-file-path',
+                inputFile.name
+            );
+            await writeStream(tempFilePath, await inputFile.stream());
+            inputFilePath = tempFilePath;
             createdTempInputFile = true;
         } else {
             inputFilePath = inputFile.path;

--- a/src/api/imageProcessor.ts
+++ b/src/api/imageProcessor.ts
@@ -21,8 +21,12 @@ export async function generateImageThumbnail(
     let createdTempInputFile = null;
     try {
         if (!existsSync(inputFile.path)) {
-            const tempFilePath = await ipcRenderer.invoke('get-temp-file-path');
-            inputFilePath = writeStream(tempFilePath, await inputFile.stream());
+            const tempFilePath = await ipcRenderer.invoke(
+                'get-temp-file-path',
+                inputFile.name
+            );
+            await writeStream(tempFilePath, await inputFile.stream());
+            inputFilePath = tempFilePath;
             createdTempInputFile = true;
         } else {
             inputFilePath = inputFile.path;

--- a/src/api/imageProcessor.ts
+++ b/src/api/imageProcessor.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron/renderer';
 import { existsSync } from 'fs';
+import { writeStream } from '../services/fs';
 import { logError } from '../services/logging';
 import { ElectronFile } from '../types';
 
@@ -20,12 +21,8 @@ export async function generateImageThumbnail(
     let createdTempInputFile = null;
     try {
         if (!existsSync(inputFile.path)) {
-            const inputFileData = new Uint8Array(await inputFile.arrayBuffer());
-            inputFilePath = await ipcRenderer.invoke(
-                'write-temp-file',
-                inputFileData,
-                inputFile.name
-            );
+            const tempFilePath = await ipcRenderer.invoke('get-temp-file-path');
+            inputFilePath = writeStream(tempFilePath, await inputFile.stream());
             createdTempInputFile = true;
         } else {
             inputFilePath = inputFile.path;

--- a/src/services/fs.ts
+++ b/src/services/fs.ts
@@ -192,7 +192,9 @@ export async function isFolder(dirPath: string) {
         .catch(() => false);
 }
 
-export const convertBrowserStreamToNode = (fileStream: any) => {
+export const convertBrowserStreamToNode = (
+    fileStream: ReadableStream<Uint8Array>
+) => {
     const reader = fileStream.getReader();
     const rs = new Readable();
 
@@ -210,10 +212,17 @@ export const convertBrowserStreamToNode = (fileStream: any) => {
     return rs;
 };
 
-export function writeStream(filePath: string, fileStream: any) {
+export function writeStream(
+    filePath: string,
+    fileStream: ReadableStream<Uint8Array>
+) {
     const writeable = fs.createWriteStream(filePath);
     const readable = convertBrowserStreamToNode(fileStream);
     readable.pipe(writeable);
+    return new Promise((resolve, reject) => {
+        writeable.on('finish', resolve);
+        writeable.on('error', reject);
+    });
 }
 
 export async function readTextFile(filePath: string) {

--- a/src/services/fs.ts
+++ b/src/services/fs.ts
@@ -212,14 +212,14 @@ export const convertBrowserStreamToNode = (
     return rs;
 };
 
-export function writeStream(
+export async function writeStream(
     filePath: string,
     fileStream: ReadableStream<Uint8Array>
 ) {
     const writeable = fs.createWriteStream(filePath);
     const readable = convertBrowserStreamToNode(fileStream);
     readable.pipe(writeable);
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
         writeable.on('finish', resolve);
         writeable.on('error', reject);
     });

--- a/src/utils/ipcComms.ts
+++ b/src/utils/ipcComms.ts
@@ -23,11 +23,8 @@ import {
     skipAppVersion,
     updateAndRestart,
 } from '../services/appUpdater';
-import {
-    deleteTempFile,
-    runFFmpegCmd,
-    writeTempFile,
-} from '../services/ffmpeg';
+import { deleteTempFile, runFFmpegCmd } from '../services/ffmpeg';
+import { generateTempFilePath } from './temp';
 
 export default function setupIpcComs(
     tray: Tray,
@@ -140,12 +137,9 @@ export default function setupIpcComs(
             return runFFmpegCmd(cmd, inputFilePath, outputFileName);
         }
     );
-    ipcMain.handle(
-        'write-temp-file',
-        (_, fileStream: Uint8Array, fileName: string) => {
-            return writeTempFile(fileStream, fileName);
-        }
-    );
+    ipcMain.handle('get-temp-file-path', (_, formatSuffix) => {
+        return generateTempFilePath(formatSuffix);
+    });
     ipcMain.handle('remove-temp-file', (_, tempFilePath: string) => {
         return deleteTempFile(tempFilePath);
     });

--- a/src/utils/temp.ts
+++ b/src/utils/temp.ts
@@ -28,11 +28,11 @@ function generateTempName(length: number) {
 }
 
 export async function generateTempFilePath(formatSuffix: string) {
-    const tempDirPath = await getTempDirPath();
-    const namePrefix = generateTempName(10);
-    const tempFilePath = path.join(
-        tempDirPath,
-        namePrefix + '-' + formatSuffix
-    );
+    let tempFilePath: string;
+    do {
+        const tempDirPath = await getTempDirPath();
+        const namePrefix = generateTempName(10);
+        tempFilePath = path.join(tempDirPath, namePrefix + '-' + formatSuffix);
+    } while (existsSync(tempFilePath));
     return tempFilePath;
 }


### PR DESCRIPTION
## Description

files inside the zip can't be read directly and where copied to a temp directory to provide input to FFmpeg. 

For creating temp file, the file was loaded in memory, which can be avoided by writing the fileStream to disk

## Test Plan

- tested zipped video and heic files are uploaded correctly
- tested normal video and heic files are uploaded correctly

