### PR TITLE
reduce log size to 5 MB

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 const PROD_HOST_URL: string = 'ente://app';
 const RENDERER_OUTPUT_DIR: string = './ui/out';
 const LOG_FILENAME = 'ente.log';
-const MAX_LOG_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
 
 const FILE_STREAM_CHUNK_SIZE: number = 4 * 1024 * 1024;
 


### PR DESCRIPTION
## Description

- reduce max log size back to 5MB, which was increased during one of beta build for crash debugging 

Doesn't need to be this big for normal use cases

## Test Plan
