### PR TITLE
Add extractImageDimensions API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ente",
     "productName": "ente",
-    "version": "1.6.29-alpha.1",
+    "version": "1.6.29-alpha.2",
     "private": true,
     "description": "Desktop client for ente.io",
     "main": "app/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ente",
     "productName": "ente",
-    "version": "1.6.28-alpha.1",
+    "version": "1.6.29-alpha.1",
     "private": true,
     "description": "Desktop client for ente.io",
     "main": "app/main.js",

--- a/src/api/ffmpeg.ts
+++ b/src/api/ffmpeg.ts
@@ -7,7 +7,7 @@ import { ElectronFile } from '../types';
 export async function runFFmpegCmd(
     cmd: string[],
     inputFile: File | ElectronFile,
-    outputFileName: string
+    outputFileName?: string
 ) {
     let inputFilePath = null;
     let createdTempInputFile = null;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -46,7 +46,11 @@ import {
 } from './api/common';
 import { fixHotReloadNext12 } from './utils/preload';
 import { isFolder, getDirFiles } from './api/fs';
-import { convertHEIC, generateImageThumbnail } from './api/imageProcessor';
+import {
+    convertHEIC,
+    generateImageThumbnail,
+    extractImageDimensions,
+} from './api/imageProcessor';
 import { setupLogging } from './utils/logging';
 import {
     setupRendererProcessStatsLogger,
@@ -105,4 +109,5 @@ windowObject['ElectronAPIs'] = {
     logRendererProcessMemoryUsage,
     registerForegroundEventListener,
     openDirectory,
+    extractImageDimensions,
 };

--- a/src/services/imageProcessor.ts
+++ b/src/services/imageProcessor.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import log from 'electron-log';
 import { CustomErrors } from '../constants/errors';
 import { Dimensions } from '../api/imageProcessor';
+import { logToDisk } from './logging';
 const shellescape = require('any-shell-escape');
 
 const asyncExec = util.promisify(exec);
@@ -347,6 +348,7 @@ function constructDimensionExtractionCommand(inputFilePath: string) {
 }
 
 function parseDimensions(dimensionsString: string): Dimensions {
+    logToDisk('dimensionsString: ' + dimensionsString);
     let dimensions: Dimensions;
     if (isPlatform('mac')) {
         dimensions = parseDimensionsMac(dimensionsString);

--- a/src/utils/ipcComms.ts
+++ b/src/utils/ipcComms.ts
@@ -15,6 +15,7 @@ import path from 'path';
 import { getDirFilePaths } from '../services/fs';
 import {
     convertHEIC,
+    extractImageDimensions,
     generateImageThumbnail,
 } from '../services/imageProcessor';
 import {
@@ -154,4 +155,8 @@ export default function setupIpcComs(
             return generateImageThumbnail(fileData, maxDimension, maxSize);
         }
     );
+
+    ipcMain.handle('extract-image-dimensions', (_, fileData) => {
+        return extractImageDimensions(fileData);
+    });
 }


### PR DESCRIPTION
## Description
- made output filename optional in `runFFmpegCmd` API to indicate the command will not output any file and the API should return the console output.
- Added ImageProcessor `extractImageDimensions`

## Test Plan

- tested the `runFFmpegCmd` API change
- Tested `extractImageDimensions` API on mac (windows pending)

