### PR TITLE
Replace semver-compare package with compare-versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
         "@types/node": "18.15.0",
         "@types/node-fetch": "^2.6.2",
         "@types/promise-fs": "^2.1.1",
-        "@types/semver-compare": "^1.0.1",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "concurrently": "^7.0.0",
@@ -104,6 +103,7 @@
         "any-shell-escape": "^0.1.1",
         "auto-launch": "^5.0.5",
         "chokidar": "^3.5.3",
+        "compare-versions": "^6.1.0",
         "electron-log": "^4.3.5",
         "electron-reload": "^2.0.0-alpha.1",
         "electron-store": "^8.0.1",
@@ -113,8 +113,7 @@
         "next-electron-server": "file:./thirdparty/next-electron-server",
         "node-fetch": "^2.6.7",
         "node-stream-zip": "^1.15.0",
-        "promise-fs": "^2.1.1",
-        "semver-compare": "^1.0.0"
+        "promise-fs": "^2.1.1"
     },
     "standard": {
         "parser": "babel-eslint"

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import { setIsAppQuitting, setIsUpdateAvailable } from '../main';
-import semVerCmp from 'semver-compare';
+import { compareVersions } from 'compare-versions';
 import { AppUpdateInfo, GetFeatureFlagResponse } from '../types';
 import {
     getMuteUpdateNotificationVersion,
@@ -34,8 +34,10 @@ async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
         const updateCheckResult = await autoUpdater.checkForUpdates();
         log.debug('update version', updateCheckResult.updateInfo.version);
         if (
-            semVerCmp(updateCheckResult.updateInfo.version, app.getVersion()) <=
-            0
+            compareVersions(
+                updateCheckResult.updateInfo.version,
+                app.getVersion()
+            ) <= 0
         ) {
             log.debug('already at latest version');
             return;
@@ -55,7 +57,7 @@ async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
         if (
             desktopCutoffVersion &&
             isPlatform('mac') &&
-            semVerCmp(
+            compareVersions(
                 updateCheckResult.updateInfo.version,
                 desktopCutoffVersion
             ) > 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,11 +375,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/semver-compare@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/semver-compare/-/semver-compare-1.0.1.tgz#17d1dc62c516c133ab01efb7803a537ee6eaf3d5"
-  integrity sha512-wx2LQVvKlEkhXp/HoKIZ/aSL+TvfJdKco8i0xJS3aR877mg4qBHzNT6+B5a61vewZHo79EdZavskGnRXEC2H6A==
-
 "@types/semver@^7.3.6":
   version "7.3.10"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.10.tgz#5f19ee40cbeff87d916eedc8c2bfe2305d957f73"
@@ -1110,6 +1105,11 @@ compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
   integrity sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==
+
+compare-versions@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
+  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
## Description

`semvar-compare` didn't support `1.0.0-alpha` like version

which will break the update if a user is on alpha/beta version 

## Test Plan

tested locally  by comparing `v1.2.3-alpha` and `v1.2.4` 
