### PR TITLE
Fix auto launch app not hidden issue [windows]

### DIFF
--- a/src/services/autoLauncher.ts
+++ b/src/services/autoLauncher.ts
@@ -1,15 +1,15 @@
 import { isPlatform } from '../utils/common/platform';
 import { AutoLauncherClient } from '../types/autoLauncher';
-import linuxAutoLauncher from './autoLauncherClients/linuxAutoLauncher';
-import macAndWindowsAutoLauncher from './autoLauncherClients/macAndWindowsAutoLauncher';
+import linuxAndWinAutoLauncher from './autoLauncherClients/linuxAndWinAutoLauncher';
+import macAutoLauncher from './autoLauncherClients/macAutoLauncher';
 
 class AutoLauncher {
     private client: AutoLauncherClient;
     init() {
-        if (isPlatform('mac') || isPlatform('windows')) {
-            this.client = macAndWindowsAutoLauncher;
+        if (isPlatform('linux') || isPlatform('windows')) {
+            this.client = linuxAndWinAutoLauncher;
         } else {
-            this.client = linuxAutoLauncher;
+            this.client = macAutoLauncher;
         }
     }
     async isEnabled() {

--- a/src/services/autoLauncher.ts
+++ b/src/services/autoLauncher.ts
@@ -5,29 +5,34 @@ import macAutoLauncher from './autoLauncherClients/macAutoLauncher';
 
 class AutoLauncher {
     private client: AutoLauncherClient;
-    init() {
+    async init() {
         if (isPlatform('linux') || isPlatform('windows')) {
             this.client = linuxAndWinAutoLauncher;
         } else {
             this.client = macAutoLauncher;
         }
+        // migrate old auto launch settings for windows from mac auto launcher to linux and windows auto launcher
+        if (isPlatform('windows') && (await macAutoLauncher.isEnabled())) {
+            await macAutoLauncher.toggleAutoLaunch();
+            await linuxAndWinAutoLauncher.toggleAutoLaunch();
+        }
     }
     async isEnabled() {
         if (!this.client) {
-            this.init();
+            await this.init();
         }
         return await this.client.isEnabled();
     }
     async toggleAutoLaunch() {
         if (!this.client) {
-            this.init();
+            await this.init();
         }
         await this.client.toggleAutoLaunch();
     }
 
-    wasAutoLaunched() {
+    async wasAutoLaunched() {
         if (!this.client) {
-            this.init();
+            await this.init();
         }
         return this.client.wasAutoLaunched();
     }

--- a/src/services/autoLauncherClients/linuxAndWinAutoLauncher.ts
+++ b/src/services/autoLauncherClients/linuxAndWinAutoLauncher.ts
@@ -1,7 +1,10 @@
 import AutoLaunch from 'auto-launch';
 import { AutoLauncherClient } from '../../types/autoLauncher';
+import { app } from 'electron';
 
-class LinuxAutoLauncher implements AutoLauncherClient {
+const LAUNCHED_AS_HIDDEN_FLAG = 'hidden';
+
+class LinuxAndWinAutoLauncher implements AutoLauncherClient {
     private instance: AutoLaunch;
     constructor() {
         const autoLauncher = new AutoLaunch({
@@ -22,8 +25,7 @@ class LinuxAutoLauncher implements AutoLauncherClient {
     }
 
     async wasAutoLaunched() {
-        // can't determine if it was auto launched
-        return false;
+        return app.commandLine.hasSwitch(LAUNCHED_AS_HIDDEN_FLAG);
     }
 
     private async disableAutoLaunch() {
@@ -34,4 +36,4 @@ class LinuxAutoLauncher implements AutoLauncherClient {
     }
 }
 
-export default new LinuxAutoLauncher();
+export default new LinuxAndWinAutoLauncher();

--- a/src/services/autoLauncherClients/macAutoLauncher.ts
+++ b/src/services/autoLauncherClients/macAutoLauncher.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import { AutoLauncherClient } from '../../types/autoLauncher';
 
-class MacAndWindowsAutoLauncher implements AutoLauncherClient {
+class MacAutoLauncher implements AutoLauncherClient {
     async isEnabled() {
         return app.getLoginItemSettings().openAtLogin;
     }
@@ -25,4 +25,4 @@ class MacAndWindowsAutoLauncher implements AutoLauncherClient {
     }
 }
 
-export default new MacAndWindowsAutoLauncher();
+export default new MacAutoLauncher();

--- a/src/utils/createWindow.ts
+++ b/src/utils/createWindow.ts
@@ -31,6 +31,9 @@ export async function createWindow(): Promise<BrowserWindow> {
         transparent: true,
         show: false,
     });
+    if (isPlatform('mac') && wasAutoLaunched) {
+        app.dock.hide();
+    }
     if (!wasAutoLaunched) {
         splash.maximize();
         splash.show();


### PR DESCRIPTION
## Description

 fixes #206, `wasOpenedAtLogin`  is a mac only property, which we were using to detect if the app was auto-launched.

moved to `auto-launch` to configure Windows, which sets a `hidden` command-line flag that we can use to detect auto-launch.

## Test Plan

tested locally on vm
