### PR TITLE
Release v1.6.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # CHANGELOG
 
-### v1.6.54
+## v1.6.55
+
+### Bug Fixes
+
+- Added manage family portal option if add-on is active
+- Fixed filename date parsing issue
+- Fixed storage limit ui glitch
+- Fixed dedupe page layout issue
+- Fixed ElectronAPI refactoring issue
+- Fixed Search related issues
+
+## v1.6.54
 
 ### New Features
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ente",
     "productName": "ente",
-    "version": "1.6.55-alpha.2",
+    "version": "1.6.55-alpha.3",
     "private": true,
     "description": "Desktop client for ente.io",
     "main": "app/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ente",
     "productName": "ente",
-    "version": "1.6.55-alpha.1",
+    "version": "1.6.55-alpha.2",
     "private": true,
     "description": "Desktop client for ente.io",
     "main": "app/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ente",
     "productName": "ente",
-    "version": "1.6.55-alpha.3",
+    "version": "1.6.55",
     "private": true,
     "description": "Desktop client for ente.io",
     "main": "app/main.js",


### PR DESCRIPTION
## Description

### Web

- https://github.com/ente-io/photos-web/pull/1479
- https://github.com/ente-io/photos-web/pull/1482
- https://github.com/ente-io/photos-web/pull/1483
- https://github.com/ente-io/photos-web/pull/1486
- https://github.com/ente-io/photos-web/pull/1489

### Desktop 
- https://github.com/ente-io/photos-web/pull/1484
- https://github.com/ente-io/photos-web/pull/1488
- #275 

### Complete changelog 
https://github.com/ente-io/photos-desktop/compare/v1.6.54...v1.6.55-alpha.2



## Test Plan
- [x] qa testing
- [x] sample dataset upload
- [x] ML run
- [x] export
- [x] watch folder
- [x] clip / search